### PR TITLE
Update vuex version in peerDependencies to remove npm WARN when using…

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
   },
   "peerDependencies": {
     "vue": "^2.0.0",
-    "vuex": "^2.0.0"
+    "vuex": ">=2.0.0"
   }
 }


### PR DESCRIPTION
… vuex 3.x