### PR TITLE
Use BroadcastChannel first in default strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.0.3 - 2020-07-16]
+## [1.0.3 - 2021-07-16]
 
 Minor release, bugfix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.0.3 - 2020-07-16]
+
+Minor release, bugfix
+
+### Fixed
+
+- Align default strategy with documentation. `BroadcastChannel` where available, `LocalStorage` as fallback.
+
 ## [1.0.0 - 2019-02-03]
 
 Major release, entire plugin rewrite

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -124,7 +124,7 @@ module.exports = function karmaConfig(config) {
     customLaunchers,
     browsers: browserStack.username
       ? Object.keys(customLaunchers)
-      : ["HeadlessChrome"],
+      : ["ChromeHeadless"],
     customHeaders: [
       {
         match: ".*\\.html",

--- a/src/strategies/defaultStrategy.js
+++ b/src/strategies/defaultStrategy.js
@@ -3,13 +3,13 @@ import LocalStorageStrategy from "./localStorage";
 
 export default function createDefaultStrategy() {
   /* istanbul ignore next: browser-dependent code */
-  if (LocalStorageStrategy.available()) {
-    return new LocalStorageStrategy();
+  if (BroadcastChannelStrategy.available()) {
+    return new BroadcastChannelStrategy();
   }
 
   /* istanbul ignore next: browser-dependent code */
-  if (BroadcastChannelStrategy.available()) {
-    return new BroadcastChannelStrategy();
+  if (LocalStorageStrategy.available()) {
+    return new LocalStorageStrategy();
   }
 
   /* istanbul ignore next: browser-dependent code */


### PR DESCRIPTION
Fix for Issue [33](https://github.com/xanf/vuex-shared-mutations/issues/33)
In the default strategy, use `BroadcastChannel` first and fallback to `localStorage`.

Also fixes `karma.conf` [Headless Chrome](https://github.com/karma-runner/karma-chrome-launcher#usage) usage.